### PR TITLE
039S1: Favourite Chargers End-to-End Integration and Validation – Authentication Fix

### DIFF
--- a/src/context/FavouritesContext.jsx
+++ b/src/context/FavouritesContext.jsx
@@ -1,4 +1,6 @@
-import React, { createContext, useState, useEffect } from "react";
+import React, { createContext, useState, useEffect, useContext } from "react";
+import { UserContext } from "./user";
+
 const API_URL = import.meta.env.VITE_API_URL;
 
 export const FavouritesContext = createContext();
@@ -8,13 +10,18 @@ export function FavouritesProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const storedUser = JSON.parse(localStorage.getItem("currentUser"));
-  const token = storedUser?.token;
+  const { user } = useContext(UserContext);
+  const token = user?.token;
 
   // Fetch favourites from backend
   useEffect(() => {
     const fetchFavourites = async () => {
-      if (!token) return;
+      if (!token) {
+        setFavourites([]);
+        setLoading(false);
+        setError(null);
+        return;
+      }
 
       setLoading(true);
       setError(null);
@@ -45,11 +52,13 @@ export function FavouritesProvider({ children }) {
   // Toggle favourite station (save/remove in DB)
   const toggleFavourite = async (station) => {
     if (!token) {
-      setError("Not authenticated");
-      return;
+      const authError = new Error("Not authenticated");
+      setError(authError.message);
+      throw authError;
     }
 
     const isFav = favourites.some((s) => s._id === station._id);
+
     const url = isFav
       ? `${API_URL}/profile/remove-favourite-station`
       : `${API_URL}/profile/add-favourite-station`;
@@ -66,20 +75,25 @@ export function FavouritesProvider({ children }) {
 
       if (!res.ok) throw new Error("Failed to update favourite");
 
-      // Optimistically update UI
+      // Update UI after successful backend request
       if (isFav) {
-        setFavourites((prev) => prev.filter((s) => s._id !== station._id));
+        setFavourites((prev) =>
+          prev.filter((s) => s._id !== station._id)
+        );
       } else {
         setFavourites((prev) => [station, ...prev]);
       }
     } catch (err) {
       console.error("Toggle favourite error:", err);
       setError(err.message);
+      throw err;
     }
   };
 
   return (
-    <FavouritesContext.Provider value={{ favourites, toggleFavourite, loading, error }}>
+    <FavouritesContext.Provider
+      value={{ favourites, toggleFavourite, loading, error }}
+    >
       {children}
     </FavouritesContext.Provider>
   );

--- a/src/context/FavouritesContext.jsx
+++ b/src/context/FavouritesContext.jsx
@@ -77,9 +77,7 @@ export function FavouritesProvider({ children }) {
 
       // Update UI after successful backend request
       if (isFav) {
-        setFavourites((prev) =>
-          prev.filter((s) => s._id !== station._id)
-        );
+        setFavourites((prev) => prev.filter((s) => s._id !== station._id));
       } else {
         setFavourites((prev) => [station, ...prev]);
       }
@@ -91,9 +89,7 @@ export function FavouritesProvider({ children }) {
   };
 
   return (
-    <FavouritesContext.Provider
-      value={{ favourites, toggleFavourite, loading, error }}
-    >
+    <FavouritesContext.Provider value={{ favourites, toggleFavourite, loading, error }}>
       {children}
     </FavouritesContext.Provider>
   );

--- a/src/pages/Favourite.jsx
+++ b/src/pages/Favourite.jsx
@@ -49,8 +49,7 @@ function Favourite() {
                   <th>Cost</th>
                   <th>Charging points</th>
                   <th>Status</th>
-                  {/* Unsave button column */}
-                  <th></th>
+                  <th></th> {/* Unsave button column */}
                 </tr>
               </thead>
               <tbody>

--- a/src/pages/Favourite.jsx
+++ b/src/pages/Favourite.jsx
@@ -49,7 +49,8 @@ function Favourite() {
                   <th>Cost</th>
                   <th>Charging points</th>
                   <th>Status</th>
-                  <th></th> {/* Unsave button column */}
+                  {/* Unsave button column */}
+                  <th></th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## Summary

This PR addresses an authentication-state issue identified during end-to-end validation of the Favourite Chargers feature.

## Issue identified

After signing in from a clean session, selecting **Save** on a charger updated the UI to **Saved**, but no `add-favourite-station` request was sent to the backend.

The Favourite context was reading authentication directly from `localStorage` instead of responding to the current `UserContext` state. Failed toggle operations could also return silently, allowing the UI to report success without persisting the favourite.

## Changes

- Updated `FavouritesContext` to use the authenticated user from `UserContext`
- Correctly reset favourites and loading state when no token is available
- Propagated authentication and API failures from `toggleFavourite`
- Cleaned up minor Favourite table markup

## Validation

End-to-end testing confirmed:

- Save charger - `POST /api/profile/add-favourite-station` -**201**
- Saved charger appears on the Favourite Chargers page
- Unsave -`POST /api/profile/remove-favourite-station` -**201**
- Removed charger remains removed after a fresh authenticated session
- `npm run build` completed successfully

## Scope

Existing unrelated Navbar filename/runtime issues and Map rendering warnings were identified during testing but intentionally kept outside this 039S1 contribution.